### PR TITLE
bug: Resolve specialties search error by casting JSONB to text

### DIFF
--- a/src/services/advocate.service.ts
+++ b/src/services/advocate.service.ts
@@ -18,7 +18,7 @@ export async function fetchAdvocatesWithPagination({
     ilike(advocates.lastName, `%${searchTerm.toLowerCase()}%`),
     ilike(advocates.city, `%${searchTerm.toLowerCase()}%`),
     ilike(advocates.degree, `%${searchTerm.toLowerCase()}%`),
-    sql`${advocates.specialties}::jsonb @> ${JSON.stringify([searchTerm])}::jsonb`,
+    sql`CAST(${advocates.specialties} AS TEXT) ILIKE ${`%${searchTerm.toLowerCase()}%`}`,
     sql`CAST(${advocates.yearsOfExperience} AS TEXT) ILIKE ${`%${searchTerm.toLowerCase()}%`}`,
   ] : [];
 
@@ -61,6 +61,6 @@ export async function fetchAdvocatesWithPagination({
 
   // Pagination
   const data = await advocateQuery.limit(limit).offset(offset);
-
+  // console.log('data', data)
   return { data, totalCount, currentPage: page, limit };
 }


### PR DESCRIPTION
Fixes an issue where searching by specialties failed due to an invalid Drizzle ORM query. The fix casts the specialties JSONB array to text before performing a partial string search.